### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ThreeDotsLabs/watermill-amazonsqs
+module github.com/m110/watermill-amazonsqs
 
 go 1.12
 


### PR DESCRIPTION
`go get` was failing with:

```
•6% ➜ go get github.com/m110/watermill-amazonsqs
go: github.com/m110/watermill-amazonsqs upgrade => v0.0.0-20200625163019-8d5def4d7c67
go get: github.com/m110/watermill-amazonsqs@v0.0.0-20200625163019-8d5def4d7c67: parsing go.mod:
	module declares its path as: github.com/ThreeDotsLabs/watermill-amazonsqs
	        but was required as: github.com/m110/watermill-amazonsqs
```

I believe this fixes it