### PR TITLE
speedup tests

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -6,6 +6,3 @@ on:
 jobs:
   ci:
     uses: ThreeDotsLabs/watermill/.github/workflows/tests.yml@master
-    with:
-      stress-tests: true
-      runs-on: ubuntu-latest-8core

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,5 +6,3 @@ on:
 jobs:
   ci:
     uses: ThreeDotsLabs/watermill/.github/workflows/tests.yml@master
-    with:
-      runs-on: ubuntu-latest-16core

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ up:
 	docker compose up -d
 
 test:
-	go test ./... -timeout=20m
+	go test ./...
 
 test_v:
 	go test -v ./...
@@ -13,7 +13,7 @@ test_short:
 	go test ./... -short
 
 test_race:
-	go test ./... -short -race -timeout=30m
+	go test ./... -short -race
 
 test_stress:
 	STRESS_TEST_COUNT=3 go test -tags=stress -timeout=45m ./...

--- a/sns/pubsub_test.go
+++ b/sns/pubsub_test.go
@@ -32,6 +32,9 @@ func TestPublishSubscribe(t *testing.T) {
 			ExactlyOnceDelivery: false,
 			GuaranteedOrder:     false,
 			Persistent:          true,
+			// Currently none of emulators are stable enough to
+			// handle all tests, see: https://github.com/localstack/localstack/issues/2074
+			ForceShort: true,
 		},
 		createPubSub,
 		createPubSubWithConsumerGroup,
@@ -54,6 +57,9 @@ func TestPubSub_arn_topic_resolver(t *testing.T) {
 				GenerateTopicFunc: func(tctx tests.TestContext) string {
 					return fmt.Sprintf("arn:aws:sns:us-west-2:000000000000:%s", tctx.TestID)
 				},
+				// Currently none of emulators are stable enough to
+				// handle all tests, see: https://github.com/localstack/localstack/issues/2074
+				ForceShort: true,
 			},
 		},
 		func(t *testing.T) (message.Publisher, message.Subscriber) {

--- a/sns/pubsub_test.go
+++ b/sns/pubsub_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func TestPublishSubscribe(t *testing.T) {
+	t.Parallel()
+
 	tests.TestPubSub(
 		t,
 		tests.Features{
@@ -37,6 +39,8 @@ func TestPublishSubscribe(t *testing.T) {
 }
 
 func TestPubSub_arn_topic_resolver(t *testing.T) {
+	t.Parallel()
+
 	tests.TestPublishSubscribe(
 		t,
 		tests.TestContext{
@@ -90,6 +94,8 @@ func TestPubSub_arn_topic_resolver(t *testing.T) {
 }
 
 func TestPublisher_CreateTopic_is_idempotent(t *testing.T) {
+	t.Parallel()
+
 	pub, _ := createPubSub(t)
 
 	topicName := watermill.NewUUID()
@@ -104,6 +110,8 @@ func TestPublisher_CreateTopic_is_idempotent(t *testing.T) {
 }
 
 func TestSubscriber_SubscribeInitialize_is_idempotent(t *testing.T) {
+	t.Parallel()
+
 	_, sub := createPubSub(t)
 
 	topicName := watermill.NewUUID()

--- a/sqs/pubsub_stress_test.go
+++ b/sqs/pubsub_stress_test.go
@@ -1,0 +1,18 @@
+//go:build stress
+// +build stress
+
+package sqs
+
+func TestPubSub_stress(t *testing.T) {
+	tests.TestPubSubStressTest(
+		t,
+		tests.Features{
+			ConsumerGroups:      false,
+			ExactlyOnceDelivery: false,
+			GuaranteedOrder:     true,
+			Persistent:          true,
+		},
+		createPubSub,
+		createPubSubWithConsumerGroup,
+	)
+}

--- a/sqs/pubsub_test.go
+++ b/sqs/pubsub_test.go
@@ -21,6 +21,8 @@ import (
 )
 
 func TestPubSub(t *testing.T) {
+	t.Parallel()
+
 	tests.TestPubSub(
 		t,
 		tests.Features{
@@ -34,21 +36,9 @@ func TestPubSub(t *testing.T) {
 	)
 }
 
-func TestPubSub_stress(t *testing.T) {
-	tests.TestPubSubStressTest(
-		t,
-		tests.Features{
-			ConsumerGroups:      false,
-			ExactlyOnceDelivery: false,
-			GuaranteedOrder:     true,
-			Persistent:          true,
-		},
-		createPubSub,
-		createPubSubWithConsumerGroup,
-	)
-}
-
 func TestPublishSubscribe_with_GenerateQueueUrlResolver(t *testing.T) {
+	t.Parallel()
+
 	tests.TestPublishSubscribe(
 		t,
 		tests.TestContext{
@@ -112,6 +102,8 @@ func TestPublishSubscribe_with_GenerateQueueUrlResolver(t *testing.T) {
 }
 
 func TestPublishSubscribe_with_TransparentUrlResolver(t *testing.T) {
+	t.Parallel()
+
 	tests.TestPublishSubscribe(
 		t,
 		tests.TestContext{
@@ -175,6 +167,8 @@ func TestPublishSubscribe_with_TransparentUrlResolver(t *testing.T) {
 }
 
 func TestPublishSubscribe_batching(t *testing.T) {
+	t.Parallel()
+
 	tests.TestPublishSubscribe(
 		t,
 		tests.TestContext{
@@ -231,6 +225,8 @@ func TestPublishSubscribe_batching(t *testing.T) {
 }
 
 func TestPublishSubscribe_creating_queue_with_different_settings_should_be_idempotent(t *testing.T) {
+	t.Parallel()
+
 	logger := watermill.NewStdLogger(false, false)
 
 	sub1, err := sqs.NewSubscriber(sqs.SubscriberConfig{
@@ -264,6 +260,8 @@ func TestPublishSubscribe_creating_queue_with_different_settings_should_be_idemp
 }
 
 func TestPublisher_GetOrCreateQueueUrl_is_idempotent(t *testing.T) {
+	t.Parallel()
+
 	pub, _ := createPubSub(t)
 
 	topicName := watermill.NewUUID()
@@ -280,6 +278,8 @@ func TestPublisher_GetOrCreateQueueUrl_is_idempotent(t *testing.T) {
 }
 
 func TestSubscriber_doesnt_hang_when_queue_doesnt_exist(t *testing.T) {
+	t.Parallel()
+
 	cfg := newAwsConfig(t)
 
 	_, sub := createPubSubWithConfig(
@@ -315,6 +315,8 @@ func TestSubscriber_doesnt_hang_when_queue_doesnt_exist(t *testing.T) {
 }
 
 func TestPublisher_do_not_create_queue(t *testing.T) {
+	t.Parallel()
+
 	cfg := newAwsConfig(t)
 
 	pub, _ := createPubSubWithConfig(

--- a/sqs/pubsub_test.go
+++ b/sqs/pubsub_test.go
@@ -30,6 +30,9 @@ func TestPubSub(t *testing.T) {
 			ExactlyOnceDelivery: false,
 			GuaranteedOrder:     true,
 			Persistent:          true,
+			// Currently none of emulators are stable enough to
+			// handle all tests, see: https://github.com/localstack/localstack/issues/2074
+			ForceShort: true,
 		},
 		createPubSub,
 		createPubSubWithConsumerGroup,
@@ -49,6 +52,9 @@ func TestPublishSubscribe_with_GenerateQueueUrlResolver(t *testing.T) {
 				GuaranteedOrder:                     true,
 				GuaranteedOrderWithSingleSubscriber: true,
 				Persistent:                          true,
+				// Currently none of emulators are stable enough to
+				// handle all tests, see: https://github.com/localstack/localstack/issues/2074
+				ForceShort: true,
 			},
 		},
 		func(t *testing.T) (message.Publisher, message.Subscriber) {
@@ -117,6 +123,9 @@ func TestPublishSubscribe_with_TransparentUrlResolver(t *testing.T) {
 				GenerateTopicFunc: func(tctx tests.TestContext) string {
 					return fmt.Sprintf("http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/%s", tctx.TestID)
 				},
+				// Currently none of emulators are stable enough to
+				// handle all tests, see: https://github.com/localstack/localstack/issues/2074
+				ForceShort: true,
 			},
 		},
 		func(t *testing.T) (message.Publisher, message.Subscriber) {
@@ -179,6 +188,9 @@ func TestPublishSubscribe_batching(t *testing.T) {
 				GuaranteedOrder:                     true,
 				GuaranteedOrderWithSingleSubscriber: true,
 				Persistent:                          true,
+				// Currently none of emulators are stable enough to
+				// handle all tests, see: https://github.com/localstack/localstack/issues/2074
+				ForceShort: true,
 			},
 		},
 		func(t *testing.T) (message.Publisher, message.Subscriber) {


### PR DESCRIPTION
### Motivation / Background

It seems that currently none of SQS/SNS emulator are capable of handling our test suite with default messages count.

### Details

I'm setting ForceShort flag for test suite, so less messages will be published and subscribed in our tests.

### Alternative approaches considered (if applicable)

I tried to use https://github.com/Admiral-Piett/goaws again, but it seems to be not fully compatible with AWS logic (code in this repo was tested with AWS and it worked, `goaws` returns some unexpected errors).

### Checklist

The resources of our team are limited. **There are a couple of things that you can do to help us merge your PR faster**:

- [ ] I wrote tests for the changes.
- [x] All tests are passing.
  - If you are testing a Pub/Sub, you can start Docker with `make up`.
  - You can start with `make test_short` for a quick check.
  - If you want to run all tests, use `make test`.
- [x] Code has no breaking changes.
- [ ] _(If applicable)_ documentation on [watermill.io](https://watermill.io/) is updated.
  - Documentation is built in the [github.com/ThreeDotsLabs/watermill/docs](https://github.com/ThreeDotsLabs/watermill/tree/master/docs).
  - You can find development instructions in the [DEVELOP.md](https://github.com/ThreeDotsLabs/watermill/tree/master/docs/DEVELOP.md).
