### PR TITLE
add configurable worker poll size

### DIFF
--- a/sqs/config.go
+++ b/sqs/config.go
@@ -40,6 +40,11 @@ type SubscriberConfig struct {
 	// GenerateDeleteMessageInput generates *sqs.DeleteMessageInput for AWS SDK.
 	GenerateDeleteMessageInput GenerateDeleteMessageInputFunc
 
+	// ConsumeWorkers is the number of goroutines that will concurrently receive and process messages
+	// from the SQS queue per Subscribe call. Each worker independently polls SQS and processes messages.
+	// Defaults to 1.
+	ConsumeWorkers int
+
 	Unmarshaler Unmarshaler
 }
 
@@ -66,6 +71,10 @@ func (c *SubscriberConfig) SetDefaults() {
 
 	if c.QueueUrlResolver == nil {
 		c.QueueUrlResolver = NewGetQueueUrlByNameUrlResolver(GetQueueUrlByNameUrlResolverConfig{})
+	}
+
+	if c.ConsumeWorkers <= 0 {
+		c.ConsumeWorkers = 1
 	}
 }
 

--- a/sqs/config_test.go
+++ b/sqs/config_test.go
@@ -7,6 +7,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSubscriberConfig_SetDefaults_ConsumeWorkers(t *testing.T) {
+	t.Run("defaults to 1 when not set", func(t *testing.T) {
+		cfg := sqs.SubscriberConfig{}
+		cfg.SetDefaults()
+		require.Equal(t, 1, cfg.ConsumeWorkers)
+	})
+
+	t.Run("defaults to 1 when set to 0", func(t *testing.T) {
+		cfg := sqs.SubscriberConfig{ConsumeWorkers: 0}
+		cfg.SetDefaults()
+		require.Equal(t, 1, cfg.ConsumeWorkers)
+	})
+
+	t.Run("defaults to 1 when negative", func(t *testing.T) {
+		cfg := sqs.SubscriberConfig{ConsumeWorkers: -5}
+		cfg.SetDefaults()
+		require.Equal(t, 1, cfg.ConsumeWorkers)
+	})
+
+	t.Run("preserves explicit positive value", func(t *testing.T) {
+		cfg := sqs.SubscriberConfig{ConsumeWorkers: 10}
+		cfg.SetDefaults()
+		require.Equal(t, 10, cfg.ConsumeWorkers)
+	})
+}
+
 func TestQueueConfigAttributes_Attributes(t *testing.T) {
 	structAttrs := sqs.QueueConfigAttributes{
 		DelaySeconds:                  "10",

--- a/sqs/pubsub_test.go
+++ b/sqs/pubsub_test.go
@@ -287,6 +287,67 @@ func TestPublishSubscribe_concurrent_workers(t *testing.T) {
 	)
 }
 
+func TestPublishSubscribe_concurrent_workers_with_batching(t *testing.T) {
+	t.Parallel()
+
+	tests.TestPublishSubscribe(
+		t,
+		tests.TestContext{
+			TestID: tests.NewTestID(),
+			Features: tests.Features{
+				ConsumerGroups:                      true,
+				ExactlyOnceDelivery:                 false,
+				GuaranteedOrder:                     false,
+				GuaranteedOrderWithSingleSubscriber: false,
+				Persistent:                          true,
+				// Currently none of emulators are stable enough to
+				// handle all tests, see: https://github.com/localstack/localstack/issues/2074
+				ForceShort: true,
+			},
+		},
+		func(t *testing.T) (message.Publisher, message.Subscriber) {
+			cfg := newAwsConfig(t)
+
+			return createPubSubWithConfig(
+				t,
+				sqs.PublisherConfig{
+					AWSConfig: cfg,
+					OptFns: []func(*amazonsqs.Options){
+						GetEndpointResolverSqs(),
+					},
+					CreateQueueConfig: sqs.QueueConfigAttributes{
+						// Default value is 30 seconds - need to be lower for tests
+						VisibilityTimeout: "1",
+					},
+					Marshaler: sqs.DefaultMarshalerUnmarshaler{},
+				},
+				sqs.SubscriberConfig{
+					AWSConfig: cfg,
+					OptFns: []func(*amazonsqs.Options){
+						GetEndpointResolverSqs(),
+					},
+					QueueConfigAttributes: sqs.QueueConfigAttributes{
+						// Default value is 30 seconds - need to be lower for tests
+						VisibilityTimeout: "1",
+					},
+					GenerateReceiveMessageInput: func(ctx context.Context, queueURL sqs.QueueURL) (*awssqs.ReceiveMessageInput, error) {
+						in, err := sqs.GenerateReceiveMessageInputDefault(ctx, queueURL)
+						if err != nil {
+							return nil, err
+						}
+
+						in.MaxNumberOfMessages = 10
+
+						return in, nil
+					},
+					ConsumeWorkers: 4,
+					Unmarshaler:    sqs.DefaultMarshalerUnmarshaler{},
+				},
+			)
+		},
+	)
+}
+
 func TestPublishSubscribe_creating_queue_with_different_settings_should_be_idempotent(t *testing.T) {
 	t.Parallel()
 

--- a/sqs/pubsub_test.go
+++ b/sqs/pubsub_test.go
@@ -236,6 +236,57 @@ func TestPublishSubscribe_batching(t *testing.T) {
 	)
 }
 
+func TestPublishSubscribe_concurrent_workers(t *testing.T) {
+	t.Parallel()
+
+	tests.TestPublishSubscribe(
+		t,
+		tests.TestContext{
+			TestID: tests.NewTestID(),
+			Features: tests.Features{
+				ConsumerGroups:                      true,
+				ExactlyOnceDelivery:                 false,
+				GuaranteedOrder:                     false,
+				GuaranteedOrderWithSingleSubscriber: false,
+				Persistent:                          true,
+				// Currently none of emulators are stable enough to
+				// handle all tests, see: https://github.com/localstack/localstack/issues/2074
+				ForceShort: true,
+			},
+		},
+		func(t *testing.T) (message.Publisher, message.Subscriber) {
+			cfg := newAwsConfig(t)
+
+			return createPubSubWithConfig(
+				t,
+				sqs.PublisherConfig{
+					AWSConfig: cfg,
+					OptFns: []func(*amazonsqs.Options){
+						GetEndpointResolverSqs(),
+					},
+					CreateQueueConfig: sqs.QueueConfigAttributes{
+						// Default value is 30 seconds - need to be lower for tests
+						VisibilityTimeout: "1",
+					},
+					Marshaler: sqs.DefaultMarshalerUnmarshaler{},
+				},
+				sqs.SubscriberConfig{
+					AWSConfig: cfg,
+					OptFns: []func(*amazonsqs.Options){
+						GetEndpointResolverSqs(),
+					},
+					QueueConfigAttributes: sqs.QueueConfigAttributes{
+						// Default value is 30 seconds - need to be lower for tests
+						VisibilityTimeout: "1",
+					},
+					ConsumeWorkers: 4,
+					Unmarshaler:    sqs.DefaultMarshalerUnmarshaler{},
+				},
+			)
+		},
+	)
+}
+
 func TestPublishSubscribe_creating_queue_with_different_settings_should_be_idempotent(t *testing.T) {
 	t.Parallel()
 

--- a/sqs/subscriber.go
+++ b/sqs/subscriber.go
@@ -95,11 +95,20 @@ func (s *Subscriber) Subscribe(ctx context.Context, topic string) (<-chan *messa
 	s.logger.With(watermill.LogFields{"queue": *resolvedQueue.QueueURL}).Info("Subscribing to queue", nil)
 
 	ctx, cancel := context.WithCancel(ctx)
-	s.subscribersWg.Add(1)
 	output := make(chan *message.Message)
 
+	var workersWg sync.WaitGroup
+	for i := 0; i < s.config.ConsumeWorkers; i++ {
+		s.subscribersWg.Add(1)
+		workersWg.Add(1)
+		go func() {
+			defer workersWg.Done()
+			s.receive(ctx, *resolvedQueue.QueueURL, output, receiveInput)
+		}()
+	}
+
 	go func() {
-		s.receive(ctx, *resolvedQueue.QueueURL, output, receiveInput)
+		workersWg.Wait()
 		close(output)
 		cancel()
 	}()


### PR DESCRIPTION

### Motivation / Background

SQS supports concurrent consumers so there is no reason not to allow it to be used with the sqs subscriber to allow for faster processing of messages.

### Details

run receive loop in multiple processes seemed like the easiet implementation approach

### Alternative approaches considered (if applicable)

making the go thread in processMessage function, but in the end it seemed slightly more complex

### Checklist

The resources of our team are limited. **There are a couple of things that you can do to help us merge your PR faster**:

- [x] I wrote tests for the changes.
- [x] All tests are passing.
  - If you are testing a Pub/Sub, you can start Docker with `make up`.
  - You can start with `make test_short` for a quick check.
  - If you want to run all tests, use `make test`.
- [x] Code has no breaking changes.
- [ ] _(If applicable)_ documentation on [watermill.io](https://watermill.io/) is updated.
  - Documentation is built in the [github.com/ThreeDotsLabs/watermill/docs](https://github.com/ThreeDotsLabs/watermill/tree/master/docs).
  - You can find development instructions in the [DEVELOP.md](https://github.com/ThreeDotsLabs/watermill/tree/master/docs/DEVELOP.md).
