### PR TITLE
fix: allow messages in flight to be drained before closing

### DIFF
--- a/sqs/config.go
+++ b/sqs/config.go
@@ -45,6 +45,19 @@ type SubscriberConfig struct {
 	// Defaults to 1.
 	ConsumeWorkers int
 
+	// CloseTimeout, when > 0, enables graceful draining on shutdown: once the
+	// subscriber starts closing, an in-flight message is not abandoned
+	// immediately. Its handler keeps a live (cancellation-detached) context and
+	// is given up to CloseTimeout to finish and ack, in which case the message
+	// is deleted normally instead of being redelivered. Only if the handler is
+	// still running when CloseTimeout elapses is its context canceled and the
+	// message abandoned for SQS to redeliver.
+	//
+	// When 0 (default), the previous behavior applies: in-flight handlers are
+	// canceled the moment the subscriber closes and their messages are left for
+	// redelivery.
+	CloseTimeout time.Duration
+
 	Unmarshaler Unmarshaler
 }
 

--- a/sqs/graceful_drain_test.go
+++ b/sqs/graceful_drain_test.go
@@ -1,0 +1,227 @@
+package sqs_test
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	amazonsqs "github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ThreeDotsLabs/watermill"
+	"github.com/ThreeDotsLabs/watermill-aws/sqs"
+	"github.com/ThreeDotsLabs/watermill/message"
+)
+
+// TestGracefulDrain_InFlightHandlerFinishesOnClose verifies that a subscriber
+// configured with CloseTimeout drains in-flight work on shutdown: when Close()
+// is called while a handler is still running, the handler keeps a live context
+// and is given time to finish and ack, so the message is deleted rather than
+// left for redelivery.
+//
+// It also cancels the context passed to Subscribe — as watermill's router does
+// the instant Close() begins (router.go: <-closingInProgressCh; cancel) — to
+// prove the in-flight handler's context is shielded from that cancellation.
+func TestGracefulDrain_InFlightHandlerFinishesOnClose(t *testing.T) {
+	t.Parallel()
+
+	const (
+		// visibilityTimeout must exceed handlerWork so the receipt handle stays
+		// valid until the drained ack deletes the message.
+		visibilityTimeout = "5"
+		closeTimeout      = 15 * time.Second
+		handlerWork       = 1500 * time.Millisecond
+	)
+
+	var deleteCalls atomic.Int32
+
+	cfg := newAwsConfig(t)
+
+	pub, err := sqs.NewPublisher(sqs.PublisherConfig{
+		AWSConfig:         cfg,
+		OptFns:            []func(*amazonsqs.Options){GetEndpointResolverSqs()},
+		CreateQueueConfig: sqs.QueueConfigAttributes{VisibilityTimeout: visibilityTimeout},
+		Marshaler:         sqs.DefaultMarshalerUnmarshaler{},
+	}, watermill.NewStdLogger(false, false))
+	require.NoError(t, err)
+	defer pub.Close()
+
+	sub, err := sqs.NewSubscriber(sqs.SubscriberConfig{
+		AWSConfig:             cfg,
+		OptFns:                []func(*amazonsqs.Options){GetEndpointResolverSqs()},
+		QueueConfigAttributes: sqs.QueueConfigAttributes{VisibilityTimeout: visibilityTimeout},
+		Unmarshaler:           sqs.DefaultMarshalerUnmarshaler{},
+		CloseTimeout:          closeTimeout,
+		GenerateDeleteMessageInput: func(ctx context.Context, queueURL sqs.QueueURL, receiptHandle *string) (*amazonsqs.DeleteMessageInput, error) {
+			deleteCalls.Add(1)
+			return sqs.GenerateDeleteMessageInputDefault(ctx, queueURL, receiptHandle)
+		},
+	}, watermill.NewStdLogger(false, false))
+	require.NoError(t, err)
+
+	topic := fmt.Sprintf("graceful-drain-%s", watermill.NewUUID())
+	require.NoError(t, sub.SubscribeInitialize(topic))
+	require.NoError(t, pub.Publish(topic, message.NewMessage(watermill.NewUUID(), []byte("payload"))))
+
+	subCtx, subCancel := context.WithCancel(context.Background())
+	defer subCancel()
+
+	out, err := sub.Subscribe(subCtx, topic)
+	require.NoError(t, err)
+
+	var (
+		received       = make(chan struct{})
+		handlerAcked   = make(chan struct{})
+		ctxStayedAlive atomic.Bool
+		receivedCount  atomic.Int32
+	)
+
+	go func() {
+		for msg := range out {
+			receivedCount.Add(1)
+			close(received)
+
+			// Work that spans the shutdown the main goroutine triggers below.
+			// If the drain works, the message context stays alive for the whole
+			// window; otherwise it is cancelled and we fall into the other case.
+			select {
+			case <-time.After(handlerWork):
+				ctxStayedAlive.Store(true)
+			case <-msg.Context().Done():
+				ctxStayedAlive.Store(false)
+			}
+
+			msg.Ack()
+			close(handlerAcked)
+			return
+		}
+	}()
+
+	select {
+	case <-received:
+	case <-time.After(20 * time.Second):
+		t.Fatal("did not receive the published message")
+	}
+
+	// Shutdown: cancel the Subscribe context (as the router does at Close) and
+	// close the subscriber. Neither must abort the in-flight handler.
+	subCancel()
+	closeReturned := make(chan error, 1)
+	go func() { closeReturned <- sub.Close() }()
+
+	select {
+	case <-handlerAcked:
+	case <-time.After(closeTimeout + 5*time.Second):
+		t.Fatal("in-flight handler did not finish during drain")
+	}
+
+	require.True(t, ctxStayedAlive.Load(),
+		"handler context was cancelled during drain; in-flight work was aborted")
+
+	select {
+	case err := <-closeReturned:
+		require.NoError(t, err)
+	case <-time.After(closeTimeout + 5*time.Second):
+		t.Fatal("Close did not return after drain")
+	}
+
+	require.EqualValues(t, 1, receivedCount.Load(), "message should be delivered exactly once")
+	require.GreaterOrEqual(t, deleteCalls.Load(), int32(1),
+		"drained ack should delete the message so it is not redelivered")
+
+	// End-to-end proof of non-redelivery: a fresh subscriber must not see the
+	// message reappear within a couple of visibility windows.
+	verifyCtx, verifyCancel := context.WithTimeout(context.Background(), 12*time.Second)
+	defer verifyCancel()
+
+	sub2, err := sqs.NewSubscriber(sqs.SubscriberConfig{
+		AWSConfig:             cfg,
+		OptFns:                []func(*amazonsqs.Options){GetEndpointResolverSqs()},
+		QueueConfigAttributes: sqs.QueueConfigAttributes{VisibilityTimeout: visibilityTimeout},
+		Unmarshaler:           sqs.DefaultMarshalerUnmarshaler{},
+	}, watermill.NewStdLogger(false, false))
+	require.NoError(t, err)
+	defer sub2.Close()
+
+	out2, err := sub2.Subscribe(verifyCtx, topic)
+	require.NoError(t, err)
+
+	select {
+	case msg, ok := <-out2:
+		if ok {
+			t.Fatalf("message was redelivered after a drained ack: %s", msg.UUID)
+		}
+	case <-verifyCtx.Done():
+		// No redelivery within the window: the drained ack really removed it.
+	}
+}
+
+// TestGracefulDrain_Disabled_AbortsInFlightOnClose documents the opt-out: with
+// CloseTimeout == 0 (the default), closing the subscriber cancels the in-flight
+// handler's context immediately, preserving the previous abort-and-redeliver
+// behavior for callers that have not opted into draining.
+func TestGracefulDrain_Disabled_AbortsInFlightOnClose(t *testing.T) {
+	t.Parallel()
+
+	cfg := newAwsConfig(t)
+
+	pub, err := sqs.NewPublisher(sqs.PublisherConfig{
+		AWSConfig:         cfg,
+		OptFns:            []func(*amazonsqs.Options){GetEndpointResolverSqs()},
+		CreateQueueConfig: sqs.QueueConfigAttributes{VisibilityTimeout: "30"},
+		Marshaler:         sqs.DefaultMarshalerUnmarshaler{},
+	}, watermill.NewStdLogger(false, false))
+	require.NoError(t, err)
+	defer pub.Close()
+
+	sub, err := sqs.NewSubscriber(sqs.SubscriberConfig{
+		AWSConfig:             cfg,
+		OptFns:                []func(*amazonsqs.Options){GetEndpointResolverSqs()},
+		QueueConfigAttributes: sqs.QueueConfigAttributes{VisibilityTimeout: "30"},
+		Unmarshaler:           sqs.DefaultMarshalerUnmarshaler{},
+		// CloseTimeout left at 0: draining disabled.
+	}, watermill.NewStdLogger(false, false))
+	require.NoError(t, err)
+
+	topic := fmt.Sprintf("graceful-drain-off-%s", watermill.NewUUID())
+	require.NoError(t, sub.SubscribeInitialize(topic))
+	require.NoError(t, pub.Publish(topic, message.NewMessage(watermill.NewUUID(), []byte("payload"))))
+
+	out, err := sub.Subscribe(context.Background(), topic)
+	require.NoError(t, err)
+
+	var (
+		received     = make(chan struct{})
+		ctxCancelled = make(chan struct{})
+	)
+
+	go func() {
+		for msg := range out {
+			close(received)
+			select {
+			case <-msg.Context().Done():
+				close(ctxCancelled) // aborted by close, as expected when draining is off
+			case <-time.After(20 * time.Second):
+			}
+			msg.Nack()
+			return
+		}
+	}()
+
+	select {
+	case <-received:
+	case <-time.After(20 * time.Second):
+		t.Fatal("did not receive the published message")
+	}
+
+	go func() { _ = sub.Close() }()
+
+	select {
+	case <-ctxCancelled:
+		// Expected: with draining disabled, close aborts the in-flight handler.
+	case <-time.After(10 * time.Second):
+		t.Fatal("handler context was not cancelled on close with CloseTimeout=0")
+	}
+}

--- a/sqs/graceful_drain_test.go
+++ b/sqs/graceful_drain_test.go
@@ -46,7 +46,7 @@ func TestGracefulDrain_InFlightHandlerFinishesOnClose(t *testing.T) {
 		Marshaler:         sqs.DefaultMarshalerUnmarshaler{},
 	}, watermill.NewStdLogger(false, false))
 	require.NoError(t, err)
-	defer pub.Close()
+	defer func() { _ = pub.Close() }()
 
 	sub, err := sqs.NewSubscriber(sqs.SubscriberConfig{
 		AWSConfig:             cfg,
@@ -79,24 +79,25 @@ func TestGracefulDrain_InFlightHandlerFinishesOnClose(t *testing.T) {
 	)
 
 	go func() {
-		for msg := range out {
-			receivedCount.Add(1)
-			close(received)
-
-			// Work that spans the shutdown the main goroutine triggers below.
-			// If the drain works, the message context stays alive for the whole
-			// window; otherwise it is cancelled and we fall into the other case.
-			select {
-			case <-time.After(handlerWork):
-				ctxStayedAlive.Store(true)
-			case <-msg.Context().Done():
-				ctxStayedAlive.Store(false)
-			}
-
-			msg.Ack()
-			close(handlerAcked)
+		msg, ok := <-out
+		if !ok {
 			return
 		}
+		receivedCount.Add(1)
+		close(received)
+
+		// Work that spans the shutdown the main goroutine triggers below.
+		// If the drain works, the message context stays alive for the whole
+		// window; otherwise it is cancelled and we fall into the other case.
+		select {
+		case <-time.After(handlerWork):
+			ctxStayedAlive.Store(true)
+		case <-msg.Context().Done():
+			ctxStayedAlive.Store(false)
+		}
+
+		msg.Ack()
+		close(handlerAcked)
 	}()
 
 	select {
@@ -143,7 +144,7 @@ func TestGracefulDrain_InFlightHandlerFinishesOnClose(t *testing.T) {
 		Unmarshaler:           sqs.DefaultMarshalerUnmarshaler{},
 	}, watermill.NewStdLogger(false, false))
 	require.NoError(t, err)
-	defer sub2.Close()
+	defer func() { _ = sub2.Close() }()
 
 	out2, err := sub2.Subscribe(verifyCtx, topic)
 	require.NoError(t, err)
@@ -174,7 +175,7 @@ func TestGracefulDrain_Disabled_AbortsInFlightOnClose(t *testing.T) {
 		Marshaler:         sqs.DefaultMarshalerUnmarshaler{},
 	}, watermill.NewStdLogger(false, false))
 	require.NoError(t, err)
-	defer pub.Close()
+	defer func() { _ = pub.Close() }()
 
 	sub, err := sqs.NewSubscriber(sqs.SubscriberConfig{
 		AWSConfig:             cfg,
@@ -198,16 +199,17 @@ func TestGracefulDrain_Disabled_AbortsInFlightOnClose(t *testing.T) {
 	)
 
 	go func() {
-		for msg := range out {
-			close(received)
-			select {
-			case <-msg.Context().Done():
-				close(ctxCancelled) // aborted by close, as expected when draining is off
-			case <-time.After(20 * time.Second):
-			}
-			msg.Nack()
+		msg, ok := <-out
+		if !ok {
 			return
 		}
+		close(received)
+		select {
+		case <-msg.Context().Done():
+			close(ctxCancelled) // aborted by close, as expected when draining is off
+		case <-time.After(20 * time.Second):
+		}
+		msg.Nack()
 	}()
 
 	select {

--- a/sqs/subscriber.go
+++ b/sqs/subscriber.go
@@ -192,15 +192,25 @@ func (s *Subscriber) processMessage(
 	logger := s.logger.With(logFields)
 	logger.Trace("processMessage", nil)
 
-	ctx, cancelCtx := context.WithCancel(ctx)
-	defer cancelCtx()
+	// handlerCtx is the context the handler sees. When graceful draining is
+	// enabled we detach it from receiver/close cancellation so an in-flight
+	// handler can finish during shutdown instead of being aborted mid-work; its
+	// lifetime is then bounded by the drain deadline below (and by any
+	// handler-side timeout). With draining disabled it stays tied to the
+	// receiver context, preserving the previous cancel-on-close behavior.
+	handlerCtx := ctx
+	if s.config.CloseTimeout > 0 {
+		handlerCtx = context.WithoutCancel(ctx)
+	}
+	handlerCtx, cancelMsg := context.WithCancel(handlerCtx)
+	defer cancelMsg()
 
 	msg, err := s.config.Unmarshaler.Unmarshal(&sqsMsg)
 	if err != nil {
 		logger.Error("Cannot unmarshal message", err, logFields)
 		return false
 	}
-	msg.SetContext(ctx)
+	msg.SetContext(handlerCtx)
 
 	logger = s.logger.With(logFields).With(watermill.LogFields{
 		"message_uuid": msg.UUID,
@@ -216,38 +226,85 @@ func (s *Subscriber) processMessage(
 		return false
 	}
 
-	select {
-	case <-msg.Acked():
-		err := s.deleteMessage(ctx, queueURL, sqsMsg.ReceiptHandle, logFields)
-		if errors.Is(err, context.Canceled) {
-			return false
+	// Wait for the handler to finish. On shutdown (s.closing, or the receiver
+	// context being canceled) we begin a bounded drain rather than abandoning
+	// the message outright: the handler keeps running for up to CloseTimeout so
+	// its work can complete and be acked. Only when that deadline elapses do we
+	// cancel the handler and abandon the message for redelivery.
+	closing := s.closing
+	ctxDone := ctx.Done()
+	var (
+		drainTimer    *time.Timer
+		drainDeadline <-chan time.Time
+	)
+	defer func() {
+		if drainTimer != nil {
+			drainTimer.Stop()
 		}
-		if err != nil {
-			logger.Error("Failed to delete message", err, logFields)
-			return false
+	}()
+	startDrain := func() {
+		if drainTimer != nil {
+			return
 		}
-	case <-msg.Nacked():
-		// Do not delete message, it will be redelivered
-		logger.Debug("Nacking message", logFields)
-		return false // we don't want to process next messages to preserve order for FIFO
-	case <-s.closing:
-		logger.Debug("Closing, message discarded before ack", logFields)
-		return false
-	case <-ctx.Done():
-		logger.Debug("Closing, ctx cancelled before ack", logFields)
-		return false
+		logger.Debug("Subscriber closing, draining in-flight message", logFields)
+		drainTimer = time.NewTimer(s.config.CloseTimeout)
+		drainDeadline = drainTimer.C
 	}
 
-	return true
+	for {
+		select {
+		case <-msg.Acked():
+			err := s.deleteMessage(handlerCtx, queueURL, sqsMsg.ReceiptHandle, logFields)
+			if errors.Is(err, context.Canceled) {
+				return false
+			}
+			if err != nil {
+				logger.Error("Failed to delete message", err, logFields)
+				return false
+			}
+			return true
+		case <-msg.Nacked():
+			// Do not delete message, it will be redelivered
+			logger.Debug("Nacking message", logFields)
+			return false // we don't want to process next messages to preserve order for FIFO
+		case <-closing:
+			closing = nil // a closed channel is always ready; react once
+			if s.config.CloseTimeout <= 0 {
+				logger.Debug("Closing, message discarded before ack", logFields)
+				return false
+			}
+			startDrain()
+		case <-ctxDone:
+			ctxDone = nil
+			if s.config.CloseTimeout <= 0 {
+				logger.Debug("Closing, ctx cancelled before ack", logFields)
+				return false
+			}
+			startDrain()
+		case <-drainDeadline:
+			cancelMsg()
+			logger.Info("Drain deadline exceeded before ack, abandoning in-flight message", logFields)
+			return false
+		}
+	}
 }
 
 func (s *Subscriber) deleteMessage(ctx context.Context, queueURL QueueURL, receiptHandle *string, logFields watermill.LogFields) error {
+	// With draining enabled the ack (and this delete) can happen after shutdown
+	// began. The caller passes a cancellation-detached context so the delete is
+	// not aborted by close; bound it here so a slow delete can't hang shutdown.
+	if s.config.CloseTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, s.config.CloseTimeout)
+		defer cancel()
+	}
+
 	input, err := s.config.GenerateDeleteMessageInput(ctx, queueURL, receiptHandle)
 	if err != nil {
 		return fmt.Errorf("cannot generate input for delete message: %w", err)
 	}
 
-	// we are using ctx that may be canceled when subscriber is closed
+	// With draining disabled, ctx may be canceled when the subscriber is closing.
 	//
 	// it may lead to re-delivery when message is processed and in the meantime
 	// subscriber is closed - but we don't know if context cancellation didn't cancel


### PR DESCRIPTION
### Motivation / Background

Currently when a shutdown signal is sent to a pod handling an in-flight message, the handler context will be canceled and the message handling will automatically be aborted. this is not ideal if we want to save on resources or not delay user facing "long running" operations.
This PR allows the user to set a drain timeout which will be waited on shutdown for all existing in flight handlers to finish while also stop accepting new messages.

### Details

Added a CloseTimeout which when != 0 will wait that specified time before aborting in-flight handlers.

### Checklist

- [ x] I wrote tests for the changes.
- [ x] All tests are passing.
- [ x] Code has no breaking changes.
